### PR TITLE
feat(savon): set `ssl_ciphers` config option

### DIFF
--- a/lib/fm_timbrado_cfdi/fm_cliente.rb
+++ b/lib/fm_timbrado_cfdi/fm_cliente.rb
@@ -63,6 +63,7 @@ module FmTimbradoCfdi
         globals.logger          logger if logger
         globals.open_timeout    15
         globals.read_timeout    15
+        globals.ssl_ciphers     'DEFAULT:@SECLEVEL=0'
       end
     end
 


### PR DESCRIPTION
The current version of OpenSSL has a default security level that is too high to communicate with Moderna, so we have to lower the SECLEVEL used by Savon.